### PR TITLE
SED PoC-specific changes

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,12 @@
 package: github.com/edgexfoundry/device-snmp-patlite-go
 import:
 - package: github.com/edgexfoundry/edgex-go
-  version: master
+  version: delhi
   subpackages:
   - /pkg/models
   - /pkg/clients/logging
 - package: github.com/edgexfoundry/device-sdk-go
-  version: master
+  version: delhi
   subpackages:
   - /pkg/models
   - /pkg/startup


### PR DESCRIPTION
Updated glide.yaml to specify dependency on delhi versions of device-sdk-go and edgex-go.

Added hack to ensure commands are processed in correct order; patlite doesn't trigger if it receives Timer before ControlState.  edgexfoundry/device-sdk-go:delhi currently has issue with deserializing wherein order is sometimes not preserved.  Issue does not exist in edgexfoundry/device-sdk-go::master as of this comment.  Hack added to facilitate SED PoC.

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>